### PR TITLE
feat(examples): add plugin-cli example exercising external subcommand dispatch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,16 @@ required-features = ["cli", "config", "logging", "shutdown", "crash", "otel"]
 name = "updater"
 required-features = ["cli", "config", "logging", "http", "cache", "update"]
 
+[[example]]
+name = "plugin-cli"
+path = "examples/plugin-cli/main.rs"
+required-features = ["cli", "config", "logging", "dispatch"]
+
+[[example]]
+name = "plugin-cli-hello-greet"
+path = "examples/plugin-cli/hello-greet/main.rs"
+required-features = ["cli"]
+
 [features]
 cli = ["dep:clap", "dep:owo-colors"]
 config = ["dep:toml", "dep:serde-saphyr", "dep:serde_json", "dep:camino", "dep:directories"]

--- a/examples/README.md
+++ b/examples/README.md
@@ -12,6 +12,7 @@ Every example is a full `main()` you can read top-to-bottom.
 | [`minimal`](minimal.rs) | Smallest idiomatic librebar app: flags, config, structured logs | `cli`, `config`, `logging` |
 | [`service`](service.rs) | Long-running async service: shutdown token, crash dumps, optional OTEL export | `cli`, `config`, `logging`, `shutdown`, `crash`, `otel` |
 | [`updater`](updater.rs) | GitHub releases check: real HTTPS call, 24h cache, `{APP}_NO_UPDATE_CHECK` gate | `cli`, `config`, `logging`, `http`, `cache`, `update` |
+| [`plugin-cli`](plugin-cli/main.rs) | Git-style external subcommand dispatch with a paired plugin binary | `cli`, `config`, `logging`, `dispatch` |
 
 ## Running
 
@@ -24,6 +25,18 @@ cargo run --example service \
     --features "cli,config,logging,shutdown,crash,otel" -- --help
 cargo run --example updater \
     --features "cli,config,logging,http,cache,update" -- --help
+cargo run --example plugin-cli \
+    --features "cli,config,logging,dispatch" -- --help
+```
+
+The `plugin-cli` example ships two binaries — the main CLI plus a paired
+`plugin-cli-hello-greet` plugin. Build both at once and prepend the
+examples directory to PATH so dispatch resolves:
+
+```sh
+cargo build --examples --features "cli,config,logging,dispatch"
+PATH="$(pwd)/target/debug/examples:$PATH" \
+    ./target/debug/examples/plugin-cli -C examples/plugin-cli hello-greet --name Clay
 ```
 
 Config discovery walks up from the current directory, so the sample `.toml`

--- a/examples/plugin-cli/hello-greet/main.rs
+++ b/examples/plugin-cli/hello-greet/main.rs
@@ -1,0 +1,30 @@
+//! Standalone plugin binary resolved as `plugin-cli-hello-greet` on PATH.
+//!
+//! Deliberately minimal and deliberately librebar-free: a plugin is just a
+//! binary whose name follows the `{app}-{subcommand}` convention. Any tool
+//! that can read argv and write stdout qualifies. If you wanted shared
+//! logging, shared config discovery, or shared exit conventions, you'd add
+//! them — but nothing in librebar's dispatch requires it.
+//!
+//! When invoked via `plugin-cli hello-greet --name Clay`, librebar's
+//! dispatch forwards the trailing args unchanged, so this binary only
+//! sees `--name Clay`.
+#![allow(missing_docs)]
+
+use clap::Parser;
+
+#[derive(Parser)]
+#[command(
+    name = "plugin-cli-hello-greet",
+    about = "Plugin subcommand: greet by name"
+)]
+struct Args {
+    /// Person to greet.
+    #[arg(long, default_value = "world")]
+    name: String,
+}
+
+fn main() {
+    let args = Args::parse();
+    println!("hello, {}!", args.name);
+}

--- a/examples/plugin-cli/main.rs
+++ b/examples/plugin-cli/main.rs
@@ -1,0 +1,169 @@
+//! Plugin-CLI example — git-style external subcommand dispatch.
+//!
+//! The main binary parses its own built-in subcommands (`info`, `which`) and
+//! forwards anything else to `{app}-{subcommand}` on PATH, the same pattern
+//! `git`, `cargo`, and `kubectl` use. The paired `hello-greet/main.rs`
+//! ships as `plugin-cli-hello-greet`, a standalone binary that knows nothing
+//! about librebar — that's the point: plugins are just PATH binaries.
+//!
+//! # Run
+//!
+//! Build both binaries in one pass:
+//!
+//! ```sh
+//! cargo build --examples --features "cli,config,logging,dispatch"
+//! ```
+//!
+//! Then run the main binary with the target/debug/examples directory
+//! prepended to PATH so the plugin resolves:
+//!
+//! ```sh
+//! PATH="$(pwd)/target/debug/examples:$PATH" \
+//!     ./target/debug/examples/plugin-cli -C examples/plugin-cli hello-greet --name Clay
+//! # → hello, Clay!
+//!
+//! # Built-in: report app state.
+//! ./target/debug/examples/plugin-cli -C examples/plugin-cli info
+//!
+//! # Built-in: resolve a plugin without running it.
+//! PATH="$(pwd)/target/debug/examples:$PATH" \
+//!     ./target/debug/examples/plugin-cli which hello-greet
+//!
+//! # Unknown subcommand — reports the expected binary name.
+//! ./target/debug/examples/plugin-cli nope
+//! ```
+//!
+//! # What it demonstrates
+//!
+//! - `#[command(external_subcommand)]` on the main `Subcommand` enum, which
+//!   makes clap hand unknown subcommands to us as `Vec<OsString>` instead of
+//!   erroring — exactly what git-style dispatch needs.
+//! - `librebar::dispatch::resolve` for "is this plugin on PATH?" lookups
+//!   (the `which` subcommand) and `librebar::dispatch::run` for the full
+//!   spawn-and-wait (the fallback arm).
+//! - `librebar::dispatch::subcommand_binary` for telling the user exactly
+//!   what binary name is expected, which is the single most helpful thing
+//!   an error message can do here.
+//! - Exit-code passthrough: when the plugin exits non-zero we exit with the
+//!   same code, so shell pipelines and CI behave as if the plugin ran directly.
+#![allow(missing_docs)]
+
+use anyhow::{Context, Result};
+use clap::{Parser, Subcommand};
+use serde::{Deserialize, Serialize};
+use std::ffi::OsString;
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(default)]
+struct Config {
+    /// Log level used as the baseline when no `-q`/`-v` flag is passed.
+    log_level: librebar::config::LogLevel,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            log_level: librebar::config::LogLevel::Info,
+        }
+    }
+}
+
+#[derive(Parser)]
+#[command(
+    name = "plugin-cli",
+    about = "Main CLI that dispatches unknown subcommands to `plugin-cli-*` binaries on PATH"
+)]
+struct Cli {
+    #[command(flatten)]
+    common: librebar::cli::CommonArgs,
+
+    #[command(subcommand)]
+    command: Option<Command>,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Report app state and plugin-resolution info.
+    Info,
+    /// Resolve `plugin-cli-<name>` on PATH without running it.
+    Which {
+        /// Name of the subcommand to look up.
+        name: String,
+    },
+    /// Any other subcommand is dispatched as `plugin-cli-<name>` on PATH.
+    #[command(external_subcommand)]
+    External(Vec<OsString>),
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+    cli.common.apply_color();
+    cli.common.apply_chdir()?;
+
+    // Hardcoded: env!("CARGO_PKG_NAME") resolves to the hosting crate
+    // (librebar) in a cargo example, not "plugin-cli".
+    let app = librebar::init("plugin-cli")
+        .with_version(env!("CARGO_PKG_VERSION"))
+        .with_cli(cli.common)
+        .config::<Config>()
+        .logging()
+        .start()?;
+
+    match cli.command.unwrap_or(Command::Info) {
+        Command::Info => print_info(&app),
+        Command::Which { name } => print_which(&app, &name),
+        Command::External(args) => dispatch_external(&app, args),
+    }
+}
+
+fn print_info(app: &librebar::App<Config>) -> Result<()> {
+    println!("app:      {} v{}", app.app_name(), app.version());
+    println!("sources:  {:?}", app.config_sources());
+    println!(
+        "log dir:  {:?}",
+        librebar::logging::platform_log_dir(app.app_name())
+    );
+    println!("built-ins: info, which");
+    println!("plugins:  any `plugin-cli-<name>` binary on PATH (try `which hello-greet`)");
+    Ok(())
+}
+
+fn print_which(app: &librebar::App<Config>, name: &str) -> Result<()> {
+    let binary = librebar::dispatch::subcommand_binary(app.app_name(), name);
+    match librebar::dispatch::resolve(app.app_name(), name) {
+        Some(path) => {
+            println!("{binary} -> {}", path.display());
+            Ok(())
+        }
+        None => {
+            anyhow::bail!("{binary} not found on PATH");
+        }
+    }
+}
+
+fn dispatch_external(app: &librebar::App<Config>, args: Vec<OsString>) -> Result<()> {
+    // clap guarantees at least the subcommand name when `external_subcommand`
+    // fires, so `split_first` is safe — but we handle the empty case anyway.
+    let (sub, rest) = args
+        .split_first()
+        .context("external subcommand requires a name")?;
+    let sub_str = sub.to_string_lossy();
+
+    tracing::info!(subcommand = %sub_str, "dispatching to external plugin");
+
+    match librebar::dispatch::run(app.app_name(), &sub_str, rest)? {
+        Some(status) => {
+            let code = status.code().unwrap_or(1);
+            if code != 0 {
+                std::process::exit(code);
+            }
+            Ok(())
+        }
+        None => {
+            let expected = librebar::dispatch::subcommand_binary(app.app_name(), &sub_str);
+            anyhow::bail!(
+                "unknown subcommand: {sub_str}. Install `{expected}` on PATH to provide it."
+            );
+        }
+    }
+}

--- a/examples/plugin-cli/plugin-cli.toml
+++ b/examples/plugin-cli/plugin-cli.toml
@@ -1,0 +1,7 @@
+# Sample config for the `plugin-cli` example.
+#
+# Demonstrates that config discovery contributes even when the config surface
+# is tiny. Run `plugin-cli -C examples/plugin-cli info` to see this file show
+# up in `sources`.
+
+log_level = "info"


### PR DESCRIPTION
Fourth (and final, for the committed series) scenario-based example.
Where `minimal`, `service`, and `updater` each lived in one file,
`plugin-cli` ships as a directory — a main binary plus a paired
plugin binary — because dispatch is only interesting when there's
actually another binary on PATH to dispatch to.
The main binary (`examples/plugin-cli/main.rs`) declares two
built-in subcommands (`info`, `which`) and catches anything else
via clap's `#[command(external_subcommand)]`, forwarding the
remaining args to `librebar::dispatch::run(app_name, sub, rest)`.
The paired plugin (`examples/plugin-cli/hello-greet/main.rs`)
builds as `plugin-cli-hello-greet` and — importantly —
doesn't depend on librebar at all. It's just a clap binary
whose name follows the `{app}-{subcommand}` convention, which
is the whole teaching point: plugins are PATH binaries, not
special harnesses.
Three dispatch surfaces are exercised directly: `resolve` powers
the `which` subcommand (lookup without executing), `run` powers
the external-subcommand arm (spawn, wait, capture exit status),
and `subcommand_binary` builds the expected binary name so
error messages can tell a user exactly what to install when a
plugin is missing.
Exit-code passthrough is explicit: when the plugin exits non-
zero, `main` calls `std::process::exit(code)` with the plugin's
code so CI pipelines and shell `$?` see the plugin's result
unchanged. Verified end-to-end — passing `--bogus` to the
plugin makes clap reject it with exit 2, and the main binary
returns 2 verbatim.
`Cargo.toml` gets two `[[example]]` entries using explicit
`path =` keys since the sources live in subdirectories. The
plugin's `required-features = ["cli"]` is narrow on purpose:
it only needs clap (librebar's `cli` feature pulls that in
as an optional dep), which reinforces that plugins can be
built and shipped independently of the main binary's feature
set. `examples/README.md` gains the row, a help recipe, and
a separate block showing the two-step build + `PATH=` run.
Verified: `just check` end-to-end — fmt, clippy
(--all-features -D warnings), deny (--all-features), 88/88
nextest, doc-tests — all green. Manual smoke: `info` reports
config source and platform log dir; `which hello-greet`
resolves to the target/debug/examples path; `which nope`
fails with a clear message; `hello-greet --name Clay`
dispatches and prints `hello, Clay!`; `hello-greet --bogus`
passes through the plugin's exit code 2; an unknown subcommand
names the expected `plugin-cli-<sub>` binary in its error.
Release-Note: Add plugin-cli example with git-style external subcommand dispatch
Release-Impact: medium