### PR TITLE
fix(tests): make network tests opt-in explicit, serialize env-var tests, document run recipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,62 @@ let app = librebar::init("myapp")
     .start()?;
 ```
 
+## Testing
+
+The default test suite runs fully offline and finishes in under a second:
+
+```sh
+just check       # fmt + clippy (--all-features) + deny + nextest + doc-tests
+just test        # just the nextest run, if you want to skip linting
+```
+
+### Opt-in network tests
+
+Two tests in `tests/http_test.rs` hit the public internet
+(`api.github.com/zen`, `httpbin.org/get`) and are marked `#[ignore]` so
+they don't pretend to pass when they haven't actually run. Opt in with:
+
+```sh
+# Run only the ignored tests (nextest):
+cargo nextest run --all-features --run-ignored only --test http_test
+
+# Or with the stock runner:
+cargo test --all-features --test http_test -- --ignored
+```
+
+### End-to-end OTEL export
+
+The `otel` feature builds an OTLP/HTTP exporter that lights up whenever
+`OTEL_EXPORTER_OTLP_ENDPOINT` is set to a non-empty value. To watch spans
+arrive from the `service` example, stand up a receiver. The .NET Aspire
+Dashboard bundles an OTLP/HTTP ingestor plus a unified UI for logs,
+traces, and metrics in a single image:
+
+```sh
+# Start the dashboard (UI on 18888, OTLP/HTTP ingestor on 18890):
+docker run --rm -d -p 18888:18888 \
+    -e DOTNET_DASHBOARD_OTLP_HTTP_ENDPOINT_URL=http://0.0.0.0:18890 \
+    -p 18890:18890 \
+    mcr.microsoft.com/dotnet/aspire-dashboard:latest
+
+# Run the service with export enabled:
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:18890 \
+    cargo run --example service \
+    --features "cli,config,logging,shutdown,crash,otel" \
+    -- -C examples run
+
+# Open the UI; spans from the `service` service show up under that name:
+#   http://localhost:18888
+#
+# First-launch login token is printed to the container logs:
+#   docker logs $(docker ps -q --filter ancestor=mcr.microsoft.com/dotnet/aspire-dashboard)
+```
+
+Any OTLP/HTTP receiver works the same way — Jaeger's `all-in-one` image,
+the OpenTelemetry Collector, or commercial backends (Honeycomb, Grafana
+Cloud, etc.). Point `OTEL_EXPORTER_OTLP_ENDPOINT` at their ingest URL and
+spans flow.
+
 ## License
 
 Licensed under either of [Apache License, Version 2.0](LICENSE-APACHE) or [MIT license](LICENSE-MIT) at your option.

--- a/examples/service.rs
+++ b/examples/service.rs
@@ -40,6 +40,10 @@
 //!     -- -C examples run
 //! ```
 //!
+//! For a full end-to-end setup (including the Docker recipe for running a
+//! Jaeger all-in-one receiver locally so you can see the spans), see the
+//! "End-to-end OTEL export" section of the project README.
+//!
 //! # What it demonstrates
 //!
 //! - `#[tokio::main(flavor = "current_thread")]` — single-threaded runtime is enough

--- a/tests/http_test.rs
+++ b/tests/http_test.rs
@@ -1,13 +1,18 @@
 #![allow(missing_docs)]
 #![cfg(feature = "http")]
 
+// Tests marked `#[ignore]` hit the public internet. The default `just test`
+// run skips them (nextest reports them as "skipped" rather than claiming a
+// silent pass). Run them explicitly with:
+//
+//     cargo nextest run --all-features --run-ignored only
+//
+// or, under the stock runner:
+//
+//     cargo test --all-features -- --ignored
+
 use librebar::http::{HttpClient, HttpClientConfig};
 use std::time::Duration;
-
-/// Run with `REBAR_TEST_NETWORK=1 cargo nextest run` to enable network tests.
-fn network_tests_enabled() -> bool {
-    std::env::var("REBAR_TEST_NETWORK").is_ok()
-}
 
 #[test]
 fn client_config_defaults() {
@@ -36,10 +41,8 @@ fn client_construction() {
 }
 
 #[tokio::test]
+#[ignore = "hits api.github.com; run with --run-ignored or `-- --ignored`"]
 async fn https_get_succeeds() {
-    if !network_tests_enabled() {
-        return;
-    }
     let client = HttpClient::from_app("librebar-test", "0.1.0").unwrap();
     let resp = client
         .get("https://api.github.com/zen")
@@ -54,10 +57,8 @@ async fn https_get_succeeds() {
 }
 
 #[tokio::test]
+#[ignore = "hits httpbin.org; run with --run-ignored or `-- --ignored`"]
 async fn http_get_succeeds() {
-    if !network_tests_enabled() {
-        return;
-    }
     let client = HttpClient::from_app("librebar-test", "0.1.0").unwrap();
     let resp = client
         .get("http://httpbin.org/get")

--- a/tests/otel_test.rs
+++ b/tests/otel_test.rs
@@ -2,21 +2,32 @@
 #![cfg(feature = "otel")]
 
 use librebar::otel::OtelConfig;
+use std::sync::{Mutex, MutexGuard};
 
-/// Clear OTEL env vars so tests run deterministically regardless of
-/// the host environment.
-fn clear_otel_env() {
-    // Safety: nextest runs each test as a separate process, so this
-    // cannot race with other threads reading env vars.
+// Process-global env vars are shared across threads. nextest sidesteps this
+// by running each test in its own process, but `cargo test` runs them on
+// threads within one process — a mutation in one test will race with a read
+// in another. This file-level lock serializes the tests that touch env so
+// the suite works under either runner.
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+/// Clear OTEL env vars so tests run deterministically regardless of the
+/// host environment. Returns a guard the caller must hold for the duration
+/// of the test body — dropping it before the test ends reopens the race.
+#[must_use = "hold the returned guard for the whole test"]
+fn clear_otel_env() -> MutexGuard<'static, ()> {
+    let guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    // SAFETY: ENV_LOCK serializes env-touching tests in this file.
     unsafe {
         std::env::remove_var("OTEL_EXPORTER_OTLP_ENDPOINT");
         std::env::remove_var("OTEL_EXPORTER_OTLP_PROTOCOL");
     }
+    guard
 }
 
 #[test]
 fn otel_config_from_app_name() {
-    clear_otel_env();
+    let _guard = clear_otel_env();
     let cfg = OtelConfig::from_app_name("test-app", "0.1.0");
     assert_eq!(cfg.service, "test-app");
     assert_eq!(cfg.version, "0.1.0");
@@ -26,7 +37,7 @@ fn otel_config_from_app_name() {
 
 #[test]
 fn otel_config_env_var_names() {
-    clear_otel_env();
+    let _guard = clear_otel_env();
     let cfg = OtelConfig::from_app_name("my-tool", "1.0.0");
     assert_eq!(cfg.env_var_endpoint, "OTEL_EXPORTER_OTLP_ENDPOINT");
     assert_eq!(cfg.env_var_protocol, "OTEL_EXPORTER_OTLP_PROTOCOL");
@@ -35,7 +46,7 @@ fn otel_config_env_var_names() {
 
 #[test]
 fn otel_config_with_endpoint() {
-    clear_otel_env();
+    let _guard = clear_otel_env();
     let cfg = OtelConfig::from_app_name("test-app", "0.1.0")
         .with_endpoint(Some("http://localhost:4318".to_string()));
     assert_eq!(cfg.endpoint.as_deref(), Some("http://localhost:4318"));
@@ -43,7 +54,7 @@ fn otel_config_with_endpoint() {
 
 #[test]
 fn build_layer_returns_none_without_endpoint() {
-    clear_otel_env();
+    let _guard = clear_otel_env();
     let cfg = OtelConfig::from_app_name("test-app", "0.1.0");
     let result = librebar::otel::build_otel_layer(&cfg);
     assert!(result.is_ok());

--- a/tests/update_test.rs
+++ b/tests/update_test.rs
@@ -2,6 +2,14 @@
 #![cfg(feature = "update")]
 
 use librebar::update::{UpdateChecker, UpdateInfo};
+use std::sync::Mutex;
+
+// Process-global env vars are shared across threads. nextest sidesteps this
+// by running each test in its own process, but `cargo test` runs them on
+// threads within one process — a mutation in one test will race with a read
+// in another. This file-level lock serializes the tests that touch env so
+// the suite works under either runner.
+static ENV_LOCK: Mutex<()> = Mutex::new(());
 
 #[test]
 fn checker_from_app_name() {
@@ -12,16 +20,19 @@ fn checker_from_app_name() {
 
 #[test]
 fn suppressed_by_env_var() {
-    // SAFETY: nextest runs each test in its own process
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    // SAFETY: ENV_LOCK serializes env-touching tests in this file.
     unsafe { std::env::set_var("TEST_APP_NO_UPDATE_CHECK", "1") };
     let checker = UpdateChecker::new("test-app", "0.1.0", "owner/repo");
     assert!(checker.is_suppressed());
+    // SAFETY: still holding ENV_LOCK.
     unsafe { std::env::remove_var("TEST_APP_NO_UPDATE_CHECK") };
 }
 
 #[test]
 fn not_suppressed_by_default() {
-    // SAFETY: nextest runs each test in its own process
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    // SAFETY: ENV_LOCK serializes env-touching tests in this file.
     unsafe { std::env::remove_var("TEST_APP_NO_UPDATE_CHECK") };
     let checker = UpdateChecker::new("test-app", "0.1.0", "owner/repo");
     assert!(!checker.is_suppressed());


### PR DESCRIPTION
Addresses two hygiene issues surfaced while auditing whether the test
suite actually earned its "green" claim, and ships the documentation
needed to run the non-default paths. Neither issue caused a real flake
in CI — one produced false-positive passes, the other only worked
under nextest's per-test-process isolation and would race under
`cargo test`.
# Network tests: silent pass -> explicit skip
`tests/http_test.rs` had two `#[tokio::test]`s that hit
`api.github.com/zen` and `httpbin.org/get`. Both were gated behind a
`REBAR_TEST_NETWORK=1` env var — if unset, each test did an early
`return` and nextest reported them as PASSED despite the bodies never
running. In CI, where the env var is never set, this meant the network
tests claimed coverage they weren't actually providing; the "88
passed" number included two that asserted nothing.
Replaced the env-var gate with `#[ignore = "..."]` attributes and a
module-level comment pointing at `--run-ignored only` (nextest) and
`-- --ignored` (stock). Nextest now reports them honestly as SKIPPED,
and the opt-in flow is a standard Rust convention instead of a
bespoke env var. Total-run count drops from "88 passed" to "86 run,
2 skipped", which is the same coverage expressed truthfully.
Verified: `cargo nextest run --all-features --run-ignored only --test
http_test` runs both bodies and both pass against the real endpoints.
# Env-var tests: serialize with a file-level Mutex
`tests/update_test.rs` and `tests/otel_test.rs` mutate process-global
env vars with `std::env::set_var` / `remove_var`. The existing
`// SAFETY: nextest runs each test in its own process` comments were
accurate under `just test`, but if anyone ever ran the suite with
stock `cargo test` — where tests run on threads within one process —
the mutations in `suppressed_by_env_var` would race with reads in
`not_suppressed_by_default`, producing sporadic failures that look
like "shouldn't this be deterministic?" bugs.
Added a file-level `static ENV_LOCK: Mutex<()> = Mutex::new(());` to
each affected test file and wrapped every env-touching test body in
`let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());`.
The `unwrap_or_else` recovers a poisoned lock after a panic in a
prior test so one failure doesn't cascade through the file.
In `otel_test.rs`, the existing `clear_otel_env()` helper was called
by every test, so it now returns `MutexGuard<'static, ()>` and the
attribute `#[must_use = "hold the returned guard for the whole
test"]` makes the required call-site pattern obvious. Dropping the
guard before the test finishes would silently reopen the race.
`Mutex::new` has been `const` since Rust 1.63, so the static works
without `lazy_static`/`once_cell`/`OnceLock`. Crate MSRV is 1.89.0.
# Documentation: Testing section covering opt-in tests and OTEL export
`README.md` gains a new "Testing" section between Builder API and
License. It documents three paths: the default `just check` loop,
the opt-in commands for the `#[ignore]`-ed network tests (for both
nextest and stock `cargo test`), and an end-to-end OTEL recipe —
Docker command to stand up the .NET Aspire Dashboard (unified UI
for logs + traces + metrics, OTLP/HTTP on 18890, UI on 18888), the
env-var + `cargo run --example service` invocation that targets it,
and a `docker logs` one-liner for fetching the first-launch login
token. A note covers the equivalence with Jaeger / the OTel
Collector / commercial backends.
`examples/service.rs`'s observability section picks up a pointer
to the README's OTEL recipe so readers who land there first know
where to find the Docker setup instead of having to Google "how do
I receive OTLP locally".
Verified: `cargo test --all-features --test update_test --test
otel_test` passes under the threaded runner (9/9), and `just check`
stays green end-to-end — fmt, clippy (--all-features -D warnings),
deny (--all-features), 86 run / 2 skipped under nextest, doc-tests —
all green.
Release-Note: Make network tests opt-in, serialize env-var tests, document test + OTEL recipes
Release-Impact: low