### PR TITLE
docs: add semver policy to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,61 @@ the OpenTelemetry Collector, or commercial backends (Honeycomb, Grafana
 Cloud, etc.). Point `OTEL_EXPORTER_OTLP_ENDPOINT` at their ingest URL and
 spans flow.
 
+## Versioning
+
+librebar follows semantic versioning with the Rust-ecosystem pre-1.0
+convention:
+
+| Release track | Behavior |
+|---------------|----------|
+| **0.x** (current) | Minor bumps (`0.1.0` → `0.2.0`) **may contain breaking changes**. Patch bumps (`0.1.0` → `0.1.1`) are additive or bug-fix only. |
+| **1.0 and beyond** | Strict semver. Breaking changes require a major bump. |
+
+### What counts as breaking
+
+During the 0.x line, the following changes warrant a minor bump:
+
+- Removing or renaming any public item (type, function, method, module,
+  feature flag).
+- Changing a public function's signature in a way that breaks existing
+  call sites — including parameter type changes, return-type changes,
+  or trait-bound tightening.
+- Adding, removing, or renaming a variant on the [`Error`](src/error.rs)
+  enum. The enum is currently exhaustive; adding `#[non_exhaustive]` to
+  it is on the roadmap and will loosen this constraint when it lands.
+- Changing the semantics of a stable API (e.g., a method that previously
+  returned `Ok(None)` now returns `Err`).
+- Raising the MSRV beyond what is documented in `rust-version` in
+  `Cargo.toml`.
+
+The following changes are **not** breaking and can land in a patch:
+
+- Adding new public items (types, functions, methods, feature flags).
+- Adding new optional config fields that have `#[serde(default)]`.
+- Internal refactoring, performance improvements, and dependency bumps
+  that don't change the public surface.
+
+### MSRV
+
+The minimum supported Rust version is pinned in `Cargo.toml`'s
+`rust-version` field (currently `1.89.0`) and tested against in CI.
+MSRV increases are treated as breaking and batched into minor bumps
+during the 0.x line and into major bumps after 1.0.
+
+### When does 1.0 ship
+
+When the public API holds stable across two consecutive minor releases
+with no breaking changes. No external gate, no calendar deadline.
+
+**Using librebar anywhere?** Open an
+[issue on GitHub](https://github.com/claylo/librebar/issues) with a
+one-line "using it for X" — not a gate for 1.0, just an invitation.
+External consumers surface ergonomic issues that self-dogfooding can't,
+and earlier signal makes for a better 1.0.
+
+Until then, pin to a specific minor version (`librebar = "0.1"`) if you
+want the patch-only guarantee.
+
 ## License
 
 Licensed under either of [Apache License, Version 2.0](LICENSE-APACHE) or [MIT license](LICENSE-MIT) at your option.


### PR DESCRIPTION
Addresses the 2026-04-11 punch-list item: librebar shipped two API-breaking changes in 72 hours on April 8-9 with nothing in the README telling downstream consumers how to interpret a version bump. This commit documents the pre-1.0 and post-1.0 contract so "breaking change" is something with a defined scope rather than something readers have to infer.

Policy, condensed:

- **0.x (current):** minor bumps may contain breaking changes, patch bumps are additive or bug-fix only. This follows the prevailing pre-1.0 convention in the Rust ecosystem (tokio, reqwest, serde_json all did this).
- **1.0+:** strict semver — breaks require a major.
- **Breaking-change definition:** removing or renaming public items, signature changes that break call sites, Error-variant additions or removals (the enum is currently exhaustive; a follow-up will add `#[non_exhaustive]` and loosen that rule), changing semantics of stable APIs, MSRV bumps.
- **Not breaking:** adding public items, adding config fields with `#[serde(default)]`, internal refactors and dep bumps that don't change the public surface.
- **MSRV:** pinned in `Cargo.toml`'s `rust-version` field, currently `1.89.0`. Bumps are breaking and batch into minor releases during 0.x, majors after 1.0.
- **1.0 trigger:** two consecutive minor releases with no breaking changes. No external gate, no calendar deadline — a readiness call, not a popularity contest. A separate invitation below that section asks anyone using librebar to open an issue with a one-line note; decoupled from the 1.0 trigger so nothing is hostage to external showups.

The section lands between "Testing" and "License" in README.md — where someone evaluating the crate naturally looks after reading the docs and before deciding to depend on it.

Verified: `just check` clean (fmt, clippy --all-features, deny, 86 nextest run / 2 skipped, doc-tests).

Release-Note: Document semver policy in README (pre-1.0 and post-1.0 contract)
Release-Impact: low

## Summary

<!-- Brief description of what this PR does (the "why", not the "what") -->

## Changes

<!-- Key changes, if not obvious from the commits -->

-

## Testing

<!-- How did you verify this works? -->

- [ ] Tests pass (`just test`)
- [ ] Lints pass (`just clippy`)

## Notes

<!-- Anything reviewers should know? Breaking changes? -->

