### PR TITLE
feat(examples): add mcp-server example exposing a single tool over stdio

### DIFF
--- a/.handoffs/2026-04-17-1133-examples-series-complete-and-pre-1-0-punch-list.md
+++ b/.handoffs/2026-04-17-1133-examples-series-complete-and-pre-1-0-punch-list.md
@@ -1,0 +1,38 @@
+# Handoff: examples series complete, pre-1.0 punch list drawn down
+
+**Date:** 2026-04-17
+**Branch:** examples-mcp-server
+**State:** Green
+
+> Green = `just check` passes (fmt → clippy --all-features → deny --all-features → 86/86 nextest → 6/17 doc-tests). Manual MCP protocol round-trip verified end-to-end.
+
+## Where things stand
+
+The committed examples series is complete: `minimal` → `service` → `updater` → `plugin-cli` → `doctor-bundle` → `mcp-server`, each exercising a distinct feature-set shape. Eight PRs landed this session (PRs #4 through #11 plus this staged-and-ready #12 for mcp-server), closing every item from the 2026-04-17-0911 handoff and most of the pre-1.0 punch list from 2026-04-11-2141.
+
+## Decisions made
+
+- **Semver policy landed (PR #9, README "Versioning" section).** Pre-1.0 convention: minor bumps may contain breaking changes, patch bumps are additive. 1.0 gate is a readiness call — not contingent on external consumers. Friendly "using it? let me know" invitation is decoupled from the trigger.
+- **Test hygiene: `#[ignore]` over env-var early-return (PR #8).** Network tests now report SKIP honestly instead of silent PASS. Env-var tests serialize with a file-level `static Mutex<()> = Mutex::new(())` so they work under `cargo test` too, not just nextest's per-process isolation.
+- **OTEL end-to-end recipe uses Aspire Dashboard in README.** Clay's preferred local receiver. Jaeger / OTel Collector / Honeycomb / Grafana Cloud work the same — just swap `OTEL_EXPORTER_OTLP_ENDPOINT`.
+- **`just doc-test` now passes `--all-features` (PR #10).** Without it, feature-gated modules' doc-blocks silently never compile. This surfaced that cache/lockfile blocks were already passing while cli/http/otel/shutdown/crash/update/bench/second-lib.rs blocks are still `ignore`.
+- **mcp-server example uses manual `ServerHandler` impl, not rmcp `#[tool]` macros.** librebar's `Cargo.toml` keeps rmcp's `macros` feature disabled so consumers don't pay the proc-macro cost if they're not using it. Example documents the tradeoff and tells readers how to opt in.
+- **MCP stdio discipline is explicit in the example doc-comment.** librebar's `logging` layer writes JSONL to file, never to stdout/stderr, which is why `.logging()` is safe to wire in an MCP server. Any added fmt layer would desync the JSON-RPC framing on stdout.
+
+## What's next
+
+1. **Merge PR #12 (staged).** `commit.txt` ready on the `examples-mcp-server` branch. `gtxt` + `git pm`.
+2. **Add `#[non_exhaustive]` to the `Error` enum in `src/error.rs`.** The semver policy explicitly promises this is on the roadmap; code doesn't reflect it yet. Once added, the policy's "adding Error variants is not breaking" clause becomes true.
+3. **Unignore the remaining 11 rustdoc blocks.** Scope for PR #10 was the four flagged in the 2026-04-11 handoff. Still ignored: `src/lib.rs:466` (a second builder example), `src/cli.rs:39`, `src/cli.rs:98`, `src/crash.rs:9`, `src/crash.rs:17`, `src/http.rs:12`, `src/otel.rs:9`, `src/shutdown.rs:9`, `src/update.rs:10`, `src/bench.rs:11`, `src/bench.rs:22`. Pattern established in PR #10 applies (hidden `#`-prefixed scaffolding + `no_run`).
+4. **Publish 0.1.0 to crates.io.** All the scaffolding is in place (package metadata, Cargo.toml exclude list, cliff.toml via scrat, SECURITY.md, README with installation snippet). Biggest unknown: `cargo publish --dry-run` to confirm nothing else blocks.
+5. **Second-half of the mcp-server example (optional).** Only `Run` and `Info` subcommands ship today; a `call` subcommand that spawns the server as a subprocess and exercises the tool round-trip would give this example the same self-contained smoke loop as the others. Not in current scope.
+
+## Landmines
+
+- **rmcp minor-version resolution.** `Cargo.toml` pins `rmcp = "1.3"`, Cargo resolved to 1.5.0. Semver-compatible, but if rmcp makes surface changes within 1.x (they did between 1.3 and 1.5 — `CallToolRequestParam` got deprecated in favor of `CallToolRequestParams`), the mcp-server example may need adjustments. Pin harder if this bites.
+- **`just doc-test` must keep `--all-features`.** If someone strips the flag "to speed up local runs," every `#[cfg(feature = "…")]` module's doc-block stops being compiled and drift sneaks back in. The `.justfile` has an explanatory comment. Don't delete it.
+- **11 rustdoc `ignore` blocks remain as rot surface.** They compile-check against nothing. If the public API they describe changes, rustdoc will render stale code happily. Item #3 above.
+- **Error enum isn't `#[non_exhaustive]` yet but the README says it will be.** The semver policy is written against a promised future state. Until item #2 lands, the policy is slightly aspirational — adding a variant today is technically breaking.
+- **MCP stdout is sacred.** librebar's logging goes to file only, which is why the example works. Any future `.fmt_layer()` or `println!` added to the server path will desync the JSON-RPC protocol on stdout. Module doc calls this out; enforcement is vigilance.
+- **`.handoffs/` and `record/` are frozen in time.** Consistent with prior handoffs. References to "rebar" or old structure in those dirs are intentional — don't bulk-rename.
+- **Smoke-testing MCP without a real client.** The verification in PR #12's commit piped handcrafted JSON-RPC through stdin. `mcp-inspector` or Claude Desktop would be a more robust loop if you're making changes to the server behavior.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,6 +110,10 @@ name = "doctor-bundle"
 required-features = ["cli", "config", "logging", "diagnostics"]
 
 [[example]]
+name = "mcp-server"
+required-features = ["cli", "config", "logging", "mcp"]
+
+[[example]]
 name = "plugin-cli-hello-greet"
 path = "examples/plugin-cli/hello-greet/main.rs"
 required-features = ["cli"]

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,6 +14,7 @@ Every example is a full `main()` you can read top-to-bottom.
 | [`updater`](updater.rs) | GitHub releases check: real HTTPS call, 24h cache, `{APP}_NO_UPDATE_CHECK` gate | `cli`, `config`, `logging`, `http`, `cache`, `update` |
 | [`plugin-cli`](plugin-cli/main.rs) | Git-style external subcommand dispatch with a paired plugin binary | `cli`, `config`, `logging`, `dispatch` |
 | [`doctor-bundle`](doctor-bundle.rs) | Health checks with `DoctorRunner` + `DebugBundle` tar.gz for bug reports | `cli`, `config`, `logging`, `diagnostics` |
+| [`mcp-server`](mcp-server.rs) | Minimal MCP server over stdio — single `greet` tool, manual `ServerHandler` impl | `cli`, `config`, `logging`, `mcp` |
 
 ## Running
 
@@ -30,6 +31,8 @@ cargo run --example plugin-cli \
     --features "cli,config,logging,dispatch" -- --help
 cargo run --example doctor-bundle \
     --features "cli,config,logging,diagnostics" -- --help
+cargo run --example mcp-server \
+    --features "cli,config,logging,mcp" -- --help
 ```
 
 The `plugin-cli` example ships two binaries — the main CLI plus a paired

--- a/examples/mcp-server.rs
+++ b/examples/mcp-server.rs
@@ -1,0 +1,216 @@
+//! MCP server example — stdio JSON-RPC with a single `greet` tool.
+//!
+//! Exercises librebar's `mcp` feature end-to-end. Implements `ServerHandler`
+//! manually (without rmcp's `#[tool]` / `#[tool_router]` macros, which
+//! librebar doesn't pull in) so readers see the actual trait surface —
+//! `get_info`, `list_tools`, `call_tool` — that the macros ordinarily
+//! generate.
+//!
+//! # Run
+//!
+//! ```sh
+//! cargo run --example mcp-server \
+//!     --features "cli,config,logging,mcp" \
+//!     -- -C examples run
+//! ```
+//!
+//! The server reads JSON-RPC on stdin and writes on stdout, so don't try
+//! to pipe the subcommand through a shell — use a real MCP client.
+//!
+//! # Inspect interactively
+//!
+//! The `mcp-inspector` utility (npm: `@modelcontextprotocol/inspector`)
+//! speaks stdio MCP and provides a local web UI for browsing capabilities
+//! and calling tools:
+//!
+//! ```sh
+//! npx @modelcontextprotocol/inspector \
+//!     cargo run --example mcp-server \
+//!     --features "cli,config,logging,mcp" \
+//!     -- run
+//! ```
+//!
+//! Point Claude Desktop at the built binary the same way by adding an
+//! entry to its `mcpServers` config with `"command"` pointing at
+//! `target/debug/examples/mcp-server`.
+//!
+//! # Why the logging stays out of stdout
+//!
+//! librebar's `logging` layer writes JSONL to a file under the platform
+//! log dir — nothing is emitted to stdout or stderr. That matters here:
+//! the stdio transport owns the JSON-RPC framing on stdout, and any log
+//! noise would desync the protocol. `-v` / `-vv` flags still work and
+//! just raise the file-layer filter.
+#![allow(missing_docs)]
+
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+use librebar::mcp::ServiceExt;
+use rmcp::{
+    ErrorData as McpError, RoleServer, ServerHandler,
+    model::{
+        CallToolRequestParams, CallToolResult, Content, ListToolsResult, PaginatedRequestParams,
+        ServerCapabilities, ServerInfo, Tool,
+    },
+    service::RequestContext,
+};
+use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
+use std::sync::Arc;
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(default)]
+struct Config {
+    /// Log level used as the baseline when no `-q`/`-v` flag is passed.
+    log_level: librebar::config::LogLevel,
+    /// Prefix the `greet` tool uses when formatting its response.
+    greeting: String,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            log_level: librebar::config::LogLevel::Info,
+            greeting: "hello".to_string(),
+        }
+    }
+}
+
+#[derive(Parser)]
+#[command(
+    name = "mcp-server",
+    about = "Example MCP server exposing a single `greet` tool over stdio"
+)]
+struct Cli {
+    #[command(flatten)]
+    common: librebar::cli::CommonArgs,
+
+    #[command(subcommand)]
+    command: Option<Command>,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Serve on stdio until the client disconnects.
+    Run,
+    /// Report app state and the configured greeting.
+    Info,
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<()> {
+    let cli = Cli::parse();
+    cli.common.apply_color();
+    cli.common.apply_chdir()?;
+
+    let app = librebar::init("mcp-server")
+        .with_version(env!("CARGO_PKG_VERSION"))
+        .with_cli(cli.common)
+        .config::<Config>()
+        .logging()
+        .start()?;
+
+    match cli.command.unwrap_or(Command::Info) {
+        Command::Run => run_server(&app).await,
+        Command::Info => {
+            print_info(&app);
+            Ok(())
+        }
+    }
+}
+
+async fn run_server(app: &librebar::App<Config>) -> Result<()> {
+    let server = GreetServer {
+        greeting: app.config().greeting.clone(),
+    };
+    tracing::info!("mcp-server starting on stdio");
+
+    let service = server.serve(librebar::mcp::transport_stdio()).await?;
+    service.waiting().await?;
+
+    tracing::info!("mcp-server client disconnected; exiting");
+    Ok(())
+}
+
+fn print_info(app: &librebar::App<Config>) {
+    let config = app.config();
+    println!("app:      {} v{}", app.app_name(), app.version());
+    println!("sources:  {:?}", app.config_sources());
+    println!("greeting: {}", config.greeting);
+    println!("tools:    greet");
+    println!(
+        "log dir:  {:?}",
+        librebar::logging::platform_log_dir(app.app_name())
+    );
+    println!();
+    println!("Run with `run` to serve on stdio (expects a connected MCP client).");
+}
+
+// ─── Server ─────────────────────────────────────────────────────────
+
+#[derive(Clone)]
+struct GreetServer {
+    greeting: String,
+}
+
+impl ServerHandler for GreetServer {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+            .with_instructions("A minimal librebar example exposing a single `greet` tool.")
+    }
+
+    async fn list_tools(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ListToolsResult, McpError> {
+        // Inline JSON Schema — librebar doesn't depend on schemars, and
+        // rmcp's `#[tool]` macros (which would generate this from a typed
+        // param struct) aren't enabled. For real servers, enable rmcp's
+        // `macros` feature in your own Cargo.toml and use the derive
+        // pattern instead of hand-rolling schemas.
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Who to greet",
+                }
+            },
+            "required": ["name"],
+        });
+        let schema_obj = schema.as_object().cloned().unwrap_or_default();
+
+        let tool = Tool::new(
+            Cow::Borrowed("greet"),
+            Cow::Borrowed("Greet someone by name with the configured prefix"),
+            Arc::new(schema_obj),
+        );
+
+        Ok(ListToolsResult::with_all_items(vec![tool]))
+    }
+
+    async fn call_tool(
+        &self,
+        request: CallToolRequestParams,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, McpError> {
+        if request.name != "greet" {
+            return Err(McpError::invalid_params(
+                format!("unknown tool: {}", request.name),
+                None,
+            ));
+        }
+
+        let name = request
+            .arguments
+            .as_ref()
+            .and_then(|args| args.get("name"))
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| McpError::invalid_params("missing required arg: name", None))?;
+
+        let output = format!("{}, {}!", self.greeting, name);
+        tracing::info!(name = %name, "greet tool invoked");
+        Ok(CallToolResult::success(vec![Content::text(output)]))
+    }
+}

--- a/examples/mcp-server.toml
+++ b/examples/mcp-server.toml
@@ -1,0 +1,7 @@
+# Sample config for the `mcp-server` example.
+#
+# Discovered via the standard walk-up from the current directory.
+# Override `greeting` to see it flow through to the `greet` tool's output.
+
+log_level = "info"
+greeting = "bonjour"


### PR DESCRIPTION
Closes the deferred examples from the 2026-04-17 handoff. The six
examples series (`minimal` → `service` → `updater` → `plugin-cli` →
`doctor-bundle` → `mcp-server`) now covers every feature-set shape
the README calls out.
# Shape
Single-file at `examples/mcp-server.rs` with a sibling
`mcp-server.toml`. Two subcommands: `run` enters the rmcp stdio serve
loop, `info` reports loaded config + log dir without touching stdio.
# Why manual ServerHandler instead of `#[tool]` macros
The calculator fixtures shipped with rmcp lean on `#[tool_router]` +
`#[tool]` attribute macros to generate `list_tools` / `call_tool` from
typed parameter structs. That pattern requires rmcp's `macros` feature,
which librebar's `Cargo.toml` doesn't enable (it pulls `rmcp-macros` +
`pastey` as extra deps, and those are only useful to consumers who use
MCP at all). Two choices:
1. Enable `macros` on librebar's `rmcp` dep so the example can use the
   ergonomic form. Costs every MCP-enabled consumer an extra proc-macro
   crate.
2. Leave librebar's feature set alone and write the trait impl by hand.
   More code in the example, but no change to what consumers inherit,
   and readers see the actual `ServerHandler` surface the macros hide.
Went with (2). The example comment explicitly says "enable rmcp's
`macros` feature in your own Cargo.toml if you want the derive
pattern" so users who find the hand-rolled schema tedious know the
path out.
# Stdio discipline
The MCP stdio transport owns both sides of stdout: JSON-RPC framing
goes out on stdout and log noise would desync the protocol. librebar's
`logging` layer writes JSONL to a file under the platform log dir and
emits nothing to stdout/stderr, so it's safe to wire `.logging()` on
the builder without a fmt layer. `-v` / `-vv` still work — they raise
the file-layer filter. The module doc calls this out explicitly so
users who add their own layers know which ones are safe.
# Clippy vs trait-return lowering
Initial impls used the `impl Future<Output = ...> + Send + '_` form
copied verbatim from the rmcp trait signature. Clippy's
`manual_async_fn` lint rejected that — the body had no early returns
or lifetime gymnastics that forced the manual form, so `async fn`
produces an equivalent future (the `MaybeSendFuture = Send` bound is
still satisfied). Converted both `list_tools` and `call_tool` to
`async fn`. The protocol round-trip stays intact.
# Verified
`just check` end-to-end — fmt, clippy (--all-features -D warnings),
deny (--all-features), 86 nextest run / 2 skipped, doc-tests (6
passed, 11 ignored) — all green. Manual protocol smoke: piped
`initialize` + `notifications/initialized` + `tools/list` +
`tools/call` as newline-delimited JSON-RPC into `./target/debug/
examples/mcp-server -C examples run` and received, in order,
`serverInfo` with `capabilities.tools` enabled and the `instructions`
string from `get_info()`, a `tools` array containing the `greet`
definition with its input schema, and a `content` block of
`"bonjour, Clay!"` — the `greeting` value from `mcp-server.toml`
flowed through the config discovery → builder → server struct →
tool body path without touching the default.
# Session handoff
`.handoffs/2026-04-17-1133-examples-series-complete-and-pre-1-0-punch-list.md`
captures the state after eight PRs landed this session (the remaining
examples series plus the full pre-1.0 punch list from the 2026-04-11
handoff), including decisions that don't live in any single commit
(semver policy reasoning, MCP stdio discipline, why the example uses
manual `ServerHandler` instead of enabling rmcp's `macros` feature),
landmines for the next session, and a prioritized what-next list
starting with `#[non_exhaustive]` on the `Error` enum and unignoring
the 11 remaining rustdoc blocks.
Release-Note: Add mcp-server example exposing a single tool over the stdio transport
Release-Impact: medium