### PR TITLE
feat(error): mark Error and companion enums `#[non_exhaustive]`

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,9 +356,10 @@ During the 0.x line, the following changes warrant a minor bump:
 - Changing a public function's signature in a way that breaks existing
   call sites — including parameter type changes, return-type changes,
   or trait-bound tightening.
-- Adding, removing, or renaming a variant on the [`Error`](src/error.rs)
-  enum. The enum is currently exhaustive; adding `#[non_exhaustive]` to
-  it is on the roadmap and will loosen this constraint when it lands.
+- Removing or renaming a variant on the [`Error`](src/error.rs) enum
+  (or any of its per-module companions: `HttpError`, `CacheError`,
+  `ConfigParseError`). These enums are all `#[non_exhaustive]`, so
+  **adding** a variant is additive and ships in a patch.
 - Changing the semantics of a stable API (e.g., a method that previously
   returned `Ok(None)` now returns `Err`).
 - Raising the MSRV beyond what is documented in `rust-version` in
@@ -367,6 +368,8 @@ During the 0.x line, the following changes warrant a minor bump:
 The following changes are **not** breaking and can land in a patch:
 
 - Adding new public items (types, functions, methods, feature flags).
+- Adding new variants to `Error`, `HttpError`, `CacheError`, or
+  `ConfigParseError` (all `#[non_exhaustive]`).
 - Adding new optional config fields that have `#[serde(default)]`.
 - Internal refactoring, performance improvements, and dependency bumps
   that don't change the public surface.

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,7 +3,12 @@
 use thiserror::Error;
 
 /// Errors that can occur during librebar initialization and operation.
+///
+/// This enum is `#[non_exhaustive]`: downstream `match` expressions must include
+/// a wildcard arm, which allows future librebar releases to add variants
+/// without a breaking change. See the README's "Versioning" section.
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum Error {
     /// Configuration file could not be parsed.
     #[cfg(feature = "config")]
@@ -93,6 +98,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 /// Errors from the HTTP client.
 #[cfg(feature = "http")]
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum HttpError {
     /// TLS provider initialization failed.
     #[error("TLS: {0}")]
@@ -120,6 +126,7 @@ pub enum HttpError {
 /// Errors from the file cache.
 #[cfg(feature = "cache")]
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum CacheError {
     /// Filesystem I/O error.
     #[error("{0}")]
@@ -135,6 +142,7 @@ pub enum CacheError {
 /// Errors from config file parsing.
 #[cfg(feature = "config")]
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum ConfigParseError {
     /// TOML parse error.
     #[error("{0}")]


### PR DESCRIPTION
Closes item #2 from the 2026-04-17-1133 handoff's pre-1.0 punch list.
The README's "Versioning" section promised this was on the roadmap; now
the code matches the policy.
# What changed
Added `#[non_exhaustive]` to:
- `Error` (top-level, in `src/error.rs`)
- `HttpError` (feature = "http")
- `CacheError` (feature = "cache")
- `ConfigParseError` (feature = "config")
All four are reachable from the public surface — `HttpError` and
`CacheError` via `#[from]` conversions into `Error`, `ConfigParseError`
via the `ConfigParse { source }` variant. Marking only the top-level
enum would have left the inner enums as a breaking-change surface,
defeating the purpose.
# Why now
`#[non_exhaustive]` is itself a breaking change (existing exhaustive
`match` expressions without a wildcard arm stop compiling). Doing it
before the first crates.io publish — item #4 on the punch list — costs
nothing. Doing it later would burn a minor bump.
# README update
The "Versioning" section previously said the enum was "currently
exhaustive; adding `#[non_exhaustive]` to it is on the roadmap." That
caveat is now stale, so the breaking-changes list becomes "removing or
renaming a variant" (not "adding") and the patch-allowed list calls
out that adding a variant on any of the four enums is additive.
# Verified
`just check` end-to-end — fmt, clippy (`--all-features -D warnings`),
deny (`--all-features`), 86 nextest / 2 skipped, doc-tests (6 passed,
11 ignored — unchanged) — all green. No call sites in the examples or
tests use exhaustive `match` on the error enums, so no follow-on edits
were needed.
Release-Note: Error, HttpError, CacheError, and ConfigParseError are now `#[non_exhaustive]` so future librebar releases can add variants without a breaking change
Release-Impact: low