### PR TITLE
fix(docs): compile the remaining 11 rustdoc examples

### DIFF
--- a/src/bench.rs
+++ b/src/bench.rs
@@ -8,7 +8,9 @@
 //!
 //! # divan (wall-clock)
 //!
-//! ```ignore
+//! ```no_run
+//! use librebar::bench::divan;
+//!
 //! fn main() {
 //!     divan::main();
 //! }
@@ -19,18 +21,26 @@
 //!
 //! # gungraun (instruction-count)
 //!
-//! ```ignore
-//! use librebar::bench::gungraun;
+//! In a real benchmark crate these items live at the top level of a
+//! `benches/*.rs` file. The `mod` wrapper below only exists so rustdoc
+//! can name-resolve `sort_vec` inside [`gungraun::library_benchmark_group!`]
+//! — rustdoc wraps each snippet in an implicit `fn main()`, which hides
+//! top-level identifiers from the macro's expansion.
 //!
-//! #[gungraun::library_benchmark]
-//! #[bench::args(1000)]
-//! fn sort_vec(n: usize) {
-//!     let mut v: Vec<u32> = (0..n as u32).rev().collect();
-//!     v.sort();
+//! ```no_run
+//! mod example_bench {
+//!     use librebar::bench::gungraun;
+//!
+//!     #[gungraun::library_benchmark]
+//!     #[bench::args(1000)]
+//!     fn sort_vec(n: usize) {
+//!         let mut v: Vec<u32> = (0..n as u32).rev().collect();
+//!         v.sort();
+//!     }
+//!
+//!     gungraun::library_benchmark_group!(name = sorting; benchmarks = sort_vec);
+//!     gungraun::main!(library_benchmark_groups = sorting);
 //! }
-//!
-//! gungraun::library_benchmark_group!(name = sorting; benchmarks = sort_vec);
-//! gungraun::main!(library_benchmark_groups = sorting);
 //! ```
 
 #[cfg(feature = "bench")]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -36,7 +36,9 @@ impl ColorChoice {
 ///
 /// Embed in your app's CLI struct with `#[command(flatten)]`:
 ///
-/// ```ignore
+/// ```
+/// use clap::{Parser, Subcommand};
+///
 /// #[derive(Parser)]
 /// struct MyCli {
 ///     #[command(flatten)]
@@ -44,6 +46,9 @@ impl ColorChoice {
 ///     #[command(subcommand)]
 ///     pub command: Option<MyCommands>,
 /// }
+///
+/// #[derive(Subcommand)]
+/// enum MyCommands { Run }
 /// ```
 #[derive(Parser, Debug)]
 pub struct CommonArgs {
@@ -95,9 +100,21 @@ impl CommonArgs {
 ///
 /// Usage: call this on the result of `YourCli::command()` before parsing:
 ///
-/// ```ignore
+/// ```no_run
+/// use clap::{CommandFactory, FromArgMatches, Parser};
+///
+/// #[derive(Parser)]
+/// struct MyCli {
+///     #[arg(long)]
+///     name: Option<String>,
+/// }
+///
+/// # fn main() -> Result<(), clap::Error> {
 /// let cmd = librebar::cli::with_help_short(MyCli::command());
 /// let cli = MyCli::from_arg_matches(&cmd.get_matches())?;
+/// # let _ = cli;
+/// # Ok(())
+/// # }
 /// ```
 pub fn with_help_short(cmd: clap::Command) -> clap::Command {
     cmd.arg(

--- a/src/crash.rs
+++ b/src/crash.rs
@@ -6,15 +6,19 @@
 //!
 //! # Usage
 //!
-//! ```ignore
+//! ```no_run
+//! # fn main() -> librebar::Result<()> {
 //! let app = librebar::init(env!("CARGO_PKG_NAME"))
 //!     .crash_handler()
 //!     .start()?;
+//! # let _ = app;
+//! # Ok(())
+//! # }
 //! ```
 //!
 //! Or install the hook directly (escape hatch):
 //!
-//! ```ignore
+//! ```no_run
 //! librebar::crash::install("myapp", env!("CARGO_PKG_VERSION"));
 //! ```
 

--- a/src/http.rs
+++ b/src/http.rs
@@ -9,12 +9,17 @@
 //!
 //! # Example
 //!
-//! ```ignore
+//! ```no_run
+//! use librebar::http::HttpClient;
+//!
+//! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 //! let client = HttpClient::from_app("my-app", "1.0.0")?;
 //! let resp = client.get("https://api.github.com/repos/owner/repo/releases/latest").await?;
 //! if resp.is_success() {
 //!     println!("{}", resp.text()?);
 //! }
+//! # Ok(())
+//! # }
 //! ```
 
 use std::time::Duration;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -463,12 +463,30 @@ macro_rules! builder_methods {
 
 /// Start building a librebar application.
 ///
-/// ```ignore
+/// ```no_run
+/// # use clap::Parser;
+/// # use serde::{Deserialize, Serialize};
+/// #
+/// # #[derive(Default, Deserialize, Serialize)]
+/// # #[serde(default)]
+/// # struct Config {}
+/// #
+/// # #[derive(Parser)]
+/// # struct Cli {
+/// #     #[command(flatten)]
+/// #     pub common: librebar::cli::CommonArgs,
+/// # }
+/// #
+/// # fn main() -> librebar::Result<()> {
+/// # let cli = Cli::parse();
 /// let app = librebar::init(env!("CARGO_PKG_NAME"))
 ///     .with_cli(cli.common)
 ///     .config::<Config>()
 ///     .logging()
 ///     .start()?;
+/// # let _ = app;
+/// # Ok(())
+/// # }
 /// ```
 pub fn init(app_name: &str) -> Builder {
     Builder {

--- a/src/otel.rs
+++ b/src/otel.rs
@@ -6,12 +6,16 @@
 //!
 //! # Standalone usage
 //!
-//! ```ignore
+//! ```no_run
 //! use librebar::otel::{OtelConfig, build_otel_layer};
 //!
+//! # fn main() -> librebar::Result<()> {
 //! let cfg = OtelConfig::from_app_name("my-tool", "0.1.0");
 //! let (layer, guard) = build_otel_layer(&cfg)?;
 //! // layer is Option — None when no endpoint is configured
+//! # let _ = (layer, guard);
+//! # Ok(())
+//! # }
 //! ```
 //!
 //! # Environment variables

--- a/src/shutdown.rs
+++ b/src/shutdown.rs
@@ -6,14 +6,18 @@
 //!
 //! # Usage
 //!
-//! ```ignore
+//! ```no_run
+//! # async fn do_work() {}
+//! # async fn example() -> librebar::Result<()> {
 //! let app = librebar::init("myapp").shutdown().start()?;
-//! let mut token = app.shutdown_token();
+//! let mut token = app.shutdown_token().expect("shutdown() was called on the builder");
 //!
 //! tokio::select! {
 //!     _ = do_work() => {},
 //!     _ = token.cancelled() => { /* cleanup */ },
 //! }
+//! # Ok(())
+//! # }
 //! ```
 
 use tokio::sync::watch;

--- a/src/update.rs
+++ b/src/update.rs
@@ -7,11 +7,13 @@
 //!
 //! # Example
 //!
-//! ```ignore
+//! ```no_run
+//! # async fn example() {
 //! let checker = librebar::update::UpdateChecker::new("myapp", "0.1.0", "owner/repo");
 //! if let Some(update) = checker.check().await {
 //!     eprintln!("{}", update.message());
 //! }
+//! # }
 //! ```
 
 use std::time::Duration;


### PR DESCRIPTION
Closes item #3 from the 2026-04-17-1133 handoff's pre-1.0 punch list.
Every rustdoc code block in librebar is now compile-checked; the
`ignore` count is zero.
# What changed
Converted all remaining `ignore` blocks to `no_run` (or plain run for
pure snippets) with hidden `#`-prefixed scaffolding, extending the
pattern established in PR #10:
- `src/lib.rs:466` (second builder example on `init`)
- `src/cli.rs:39` (`CommonArgs` flatten example)
- `src/cli.rs:98` (`with_help_short` example)
- `src/crash.rs:9` (builder example)
- `src/crash.rs:17` (`install` escape hatch)
- `src/http.rs:12` (async `HttpClient::get`)
- `src/otel.rs:9` (`OtelConfig` + `build_otel_layer`)
- `src/shutdown.rs:9` (`tokio::select!` example)
- `src/update.rs:10` (async `UpdateChecker`)
- `src/bench.rs:11` (divan)
- `src/bench.rs:22` (gungraun)
Doc-test tally: 6 passed / 11 ignored → 17 passed / 0 ignored.
# Doc-drift caught by unignoring
The `src/shutdown.rs` snippet called `.cancelled()` directly on the
result of `app.shutdown_token()` — but `shutdown_token` returns
`Option<ShutdownToken>` (returns `None` when the builder didn't call
`.shutdown()`). The example would never have compiled against the real
API. This is exactly the rot the handoff flagged:
> "11 rustdoc ignore blocks remain as rot surface. They compile-check
>  against nothing. If the public API they describe changes, rustdoc
>  will render stale code happily."
Fixed the example to `.expect("shutdown() was called on the builder")`
so the demonstrated usage matches what callers actually have to write.
# Two non-obvious patterns applied
**`src/http.rs` wrapper return type.** The snippet uses `resp.text()?`,
and `Response::text` returns `Result<String, FromUtf8Error>` —
librebar's `Error` doesn't have a `From<FromUtf8Error>` impl (nor
should it, since UTF-8 decoding of response bodies is a caller
concern, not a framework one). Wrapping the example in
`async fn example() -> Result<(), Box<dyn std::error::Error>>` lets
the `?` on both `from_app` (librebar::Error) and `text` (FromUtf8Error)
compile without polluting the framework's error surface.
**`src/bench.rs` gungraun module wrapper.** rustdoc wraps each snippet
in an implicit `fn main()`, which nests top-level items — but
`gungraun::library_benchmark_group!(... benchmarks = sort_vec)`
resolves `sort_vec` as a crate-root path. The macro expansion fails to
find the (now-nested) identifier. Wrapping the snippet in a
`mod example_bench { ... }` gives the macro a stable scope to resolve
against. The doc-block has a short comment explaining why the `mod`
exists, so readers understand it's a doctest-scaffolding artifact, not
something that appears in real gungraun usage.
# Verified
`just check` end-to-end — fmt, clippy (`--all-features -D warnings`),
deny (`--all-features`), 86 nextest / 2 skipped, **17 doc-tests
passed / 0 ignored** — all green.
Release-Note: Compile-check all rustdoc examples; no rustdoc blocks remain ignored
Release-Impact: low