### PR TITLE
feat(examples): add mcp-server `call` subcommand for self-contained round-trip

### DIFF
--- a/examples/mcp-server.rs
+++ b/examples/mcp-server.rs
@@ -17,6 +17,20 @@
 //! The server reads JSON-RPC on stdin and writes on stdout, so don't try
 //! to pipe the subcommand through a shell — use a real MCP client.
 //!
+//! # Smoke test
+//!
+//! The `call` subcommand spawns the same binary as a subprocess with
+//! `run`, drives the handshake (initialize → notifications/initialized
+//! → tools/call), and prints the `greet` response — a self-contained
+//! round-trip that doesn't need an external MCP client:
+//!
+//! ```sh
+//! cargo run --example mcp-server \
+//!     --features "cli,config,logging,mcp" \
+//!     -- -C examples call --name Clay
+//! # → bonjour, Clay!     (using greeting from examples/mcp-server.toml)
+//! ```
+//!
 //! # Inspect interactively
 //!
 //! The `mcp-inspector` utility (npm: `@modelcontextprotocol/inspector`)
@@ -43,7 +57,7 @@
 //! just raise the file-layer filter.
 #![allow(missing_docs)]
 
-use anyhow::Result;
+use anyhow::{Context, Result, bail};
 use clap::{Parser, Subcommand};
 use librebar::mcp::ServiceExt;
 use rmcp::{
@@ -56,6 +70,8 @@ use rmcp::{
 };
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
+use std::io::{BufRead, BufReader, Write};
+use std::process::{Command as StdCommand, Stdio};
 use std::sync::Arc;
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -95,6 +111,16 @@ enum Command {
     Run,
     /// Report app state and the configured greeting.
     Info,
+    /// Spawn the server as a subprocess and round-trip one `greet` call.
+    ///
+    /// Self-contained smoke loop — useful for CI and for readers who want
+    /// to see the full handshake (initialize → notifications/initialized
+    /// → tools/call) without wiring up `mcp-inspector` or Claude Desktop.
+    Call {
+        /// Name to greet. Defaults to "world".
+        #[arg(long, default_value = "world")]
+        name: String,
+    },
 }
 
 #[tokio::main(flavor = "current_thread")]
@@ -116,6 +142,7 @@ async fn main() -> Result<()> {
             print_info(&app);
             Ok(())
         }
+        Command::Call { name } => round_trip_call(&name),
     }
 }
 
@@ -144,6 +171,105 @@ fn print_info(app: &librebar::App<Config>) {
     );
     println!();
     println!("Run with `run` to serve on stdio (expects a connected MCP client).");
+}
+
+// ─── Client (smoke-test round-trip) ─────────────────────────────────
+
+/// Spawn this same binary with `run`, drive the MCP handshake over the
+/// child's stdio, invoke the `greet` tool once, and print the result.
+///
+/// Uses blocking `std::process` + `std::io` deliberately: the surrounding
+/// `#[tokio::main]` runtime isn't doing anything else during this path,
+/// and keeping the subprocess I/O synchronous avoids pulling tokio's
+/// `process` and `io-util` features into librebar just for an example.
+fn round_trip_call(name: &str) -> Result<()> {
+    let exe = std::env::current_exe().context("locating current executable")?;
+    eprintln!("round-trip: spawning `{} run`", exe.display());
+
+    let mut child = StdCommand::new(&exe)
+        .arg("run")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .context("spawning mcp-server subprocess")?;
+
+    let mut stdin = child.stdin.take().context("child stdin missing")?;
+    let stdout = child.stdout.take().context("child stdout missing")?;
+    let mut reader = BufReader::new(stdout);
+
+    let initialize = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": { "name": "mcp-server-example-call", "version": "0.0.0" }
+        }
+    });
+    let initialized = serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": "notifications/initialized"
+    });
+    let call = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "tools/call",
+        "params": {
+            "name": "greet",
+            "arguments": { "name": name }
+        }
+    });
+
+    writeln!(stdin, "{initialize}")?;
+    writeln!(stdin, "{initialized}")?;
+    writeln!(stdin, "{call}")?;
+    stdin.flush()?;
+
+    // Read line-delimited JSON-RPC messages until we see a response to
+    // our `tools/call` (id = 2). The `initialize` response (id = 1) comes
+    // first; we log it for the reader's benefit and move on.
+    let mut result_text = None;
+    let mut line = String::new();
+    while result_text.is_none() {
+        line.clear();
+        let n = reader
+            .read_line(&mut line)
+            .context("reading response from mcp-server")?;
+        if n == 0 {
+            break;
+        }
+        let resp: serde_json::Value = serde_json::from_str(line.trim())
+            .with_context(|| format!("parsing response: {}", line.trim()))?;
+
+        match resp.get("id").and_then(|v| v.as_i64()) {
+            Some(1) => eprintln!("round-trip: initialize acknowledged"),
+            Some(2) => {
+                result_text = resp
+                    .pointer("/result/content/0/text")
+                    .and_then(|v| v.as_str())
+                    .map(String::from);
+            }
+            _ => {}
+        }
+    }
+
+    // Closing stdin signals EOF to the server's stdio transport, which
+    // completes the service future and lets the subprocess exit cleanly.
+    drop(stdin);
+    let status = child.wait().context("waiting on mcp-server subprocess")?;
+    if !status.success() {
+        bail!("mcp-server subprocess exited with status {status}");
+    }
+
+    match result_text {
+        Some(text) => {
+            println!("{text}");
+            Ok(())
+        }
+        None => bail!("no result payload returned from tools/call"),
+    }
 }
 
 // ─── Server ─────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes item #5 from the 2026-04-17-1133 handoff's pre-1.0 punch list.
The mcp-server example now has the same self-contained smoke loop as
the others in the series — build it, invoke it, observe the result —
with no external MCP client required.
# What `call` does
`mcp-server call [--name NAME]` spawns the same binary as a subprocess
with the `run` subcommand (via `std::env::current_exe()`), drives the
JSON-RPC handshake over the child's stdio, invokes the `greet` tool
once, and prints the result to stdout:
```sh
$ ./target/debug/examples/mcp-server -C examples call --name Clay
round-trip: spawning `.../target/debug/examples/mcp-server run`
round-trip: initialize acknowledged
bonjour, Clay!
```
The eprintln! progress lines go to stderr so stdout stays clean for the
tool payload — scripts or CI smoke tests can `$(mcp-server … call)`
and capture just the result.
# Why synchronous std::process
The surrounding `#[tokio::main]` runtime isn't doing anything else
during the `call` path, and switching to `tokio::process::Command` plus
`tokio::io::BufReader::read_line` would pull tokio's `process` and
`io-util` features into librebar's dev-dependencies solely for one
smoke path. Blocking stdlib I/O inside the already-present tokio
current-thread runtime is fine here — no other work is competing for
the thread, and `child.wait()` is the last call on the path.
# EOF-driven server shutdown
Dropping the child's stdin after writing the three messages signals EOF
to the rmcp stdio transport, which completes the service future and
lets the subprocess exit cleanly on its own. No kill, no signal, no
explicit shutdown notification required.
# Verified
- `./target/debug/examples/mcp-server -C examples call --name Clay`
  → "bonjour, Clay!" (config `greeting = "bonjour"` applied to
  argument `name = "Clay"`).
- `./target/debug/examples/mcp-server -C examples call`
  → "bonjour, world!" (default `--name` value).
- Run from `/tmp` with no config discoverable →
  "hello, ada!" (default greeting from `Config::default`).
- `just check` end-to-end — fmt, clippy (`--all-features -D warnings`),
  deny (`--all-features`), 86 nextest / 2 skipped, 17 doc-tests / 0
  ignored — all green.
Release-Note: mcp-server example gains a `call` subcommand that exercises the full MCP handshake + greet tool round-trip via subprocess, usable as a CI smoke test without an external MCP client
Release-Impact: low